### PR TITLE
Add one day grace on image querys being in future

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wintertoo"
-version = "1.3.0"
+version = "1.3.1"
 description = ""
 authors = [
     {name = "Robert Stein", email = "rdstein@caltech.edu"},

--- a/wintertoo/models/image.py
+++ b/wintertoo/models/image.py
@@ -31,13 +31,13 @@ class ProgramImageQuery(BaseModel):
     )
     start_date: int = Field(
         title="Start date for images",
-        le=get_date(Time.now()),
+        le=get_date(Time.now() + 1 * u.day),
         default=get_date(Time.now() - 30.0 * u.day),
         examples=[get_date(Time.now() - 30.0 * u.day), "20230601"],
     )
     end_date: int = Field(
         title="End date for images",
-        le=get_date(Time.now()),
+        le=get_date(Time.now() + 1 * u.day),
         default=get_date(Time.now()),
         examples=[get_date(Time.now() - 30.0 * u.day), get_date(Time.now())],
     )


### PR DESCRIPTION
Otherwise the default winterapi time might be ahead of the server time due to time zones.