### PR TITLE
Swap to validation after initialisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wintertoo"
-version = "1.3.1"
+version = "1.3.2"
 description = ""
 authors = [
     {name = "Robert Stein", email = "rdstein@caltech.edu"},

--- a/wintertoo/models/image.py
+++ b/wintertoo/models/image.py
@@ -31,19 +31,41 @@ class ProgramImageQuery(BaseModel):
     )
     start_date: int = Field(
         title="Start date for images",
-        le=get_date(Time.now() + 1 * u.day),
         default=get_date(Time.now() - 30.0 * u.day),
         examples=[get_date(Time.now() - 30.0 * u.day), "20230601"],
     )
     end_date: int = Field(
         title="End date for images",
-        le=get_date(Time.now() + 1 * u.day),
         default=get_date(Time.now()),
         examples=[get_date(Time.now() - 30.0 * u.day), get_date(Time.now())],
     )
     kind: WinterImageTypes = Field(
         default=DEFAULT_IMAGE_TYPE, example="raw/science/diff"
     )
+
+    @model_validator(mode="after")
+    def validate_date_order(self):
+        """
+        Ensure that the start date is before the end date
+
+        :return: validated field value
+        """
+        if self.start_date > self.end_date:
+            raise WinterValidationError("Start date is after end date")
+
+        today = get_date(Time.now())
+
+        if self.start_date > today:
+            raise WinterValidationError(
+                f"Start date is in the future, (today is {today})"
+            )
+
+        if self.end_date > today:
+            raise WinterValidationError(
+                f"End date is in the future, (today is {today})"
+            )
+
+        return self
 
 
 class TargetImageQuery(ProgramImageQuery):


### PR DESCRIPTION
Big date bug: I think the pydantic maximums for end date etc are set at initialisation and therefore won't update over time. Now using a post-creation check instead. 