### PR TITLE
V1.5.0 - Add avro image type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wintertoo"
-version = "1.4.0"
+version = "1.5.0"
 description = ""
 authors = [
     {name = "Robert Stein", email = "rdstein@caltech.edu"},

--- a/wintertoo/data/__init__.py
+++ b/wintertoo/data/__init__.py
@@ -32,7 +32,7 @@ WINTER_BASE_WIDTH = 1.0
 
 MAX_TARGNAME_LEN = 30
 
-WinterImageTypes = Literal["exposure", "raw", "science", "stack", "diff"]
+WinterImageTypes = Literal["exposure", "raw", "science", "stack", "diff", "avro"]
 DEFAULT_IMAGE_TYPE = "stack"
 
 PROGRAM_DB_HOST = "jagati.caltech.edu"

--- a/wintertoo/models/image.py
+++ b/wintertoo/models/image.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from astropy import units as u
 from astropy.time import Time
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 from wintertoo.data import DEFAULT_IMAGE_TYPE, MAX_TARGNAME_LEN, WinterImageTypes
 from wintertoo.errors import WinterValidationError
@@ -39,8 +39,10 @@ class ProgramImageQuery(BaseModel):
         default=get_date(Time.now()),
         examples=[get_date(Time.now() - 30.0 * u.day), get_date(Time.now())],
     )
-    kind: WinterImageTypes = Field(
-        default=DEFAULT_IMAGE_TYPE, example="raw/science/diff"
+    image_type: WinterImageTypes = Field(
+        default=DEFAULT_IMAGE_TYPE,
+        example="raw/science/diff",
+        validation_alias=AliasChoices("image_type", "kind"),
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
This PR:

- adds `avro` as an image type
- Renames `kind` to `image_type`
- Bumps version to v1.5.0  