### PR TITLE
Set default date range at instantiation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,6 @@ disable=["logging-fstring-interpolation"]
 good-names=["ax", "ra", "df", "pi", "i"]
 exclude-too-few-public-methods=["pydantic.*"]
 extension-pkg-whitelist=["pydantic"]
+
+[tool.pylint.typecheck]
+generated-members=["u.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wintertoo"
-version = "1.5.0"
+version = "1.5.1"
 description = ""
 authors = [
     {name = "Robert Stein", email = "rdstein@caltech.edu"},

--- a/wintertoo/models/image.py
+++ b/wintertoo/models/image.py
@@ -31,12 +31,12 @@ class ProgramImageQuery(BaseModel):
     )
     start_date: int = Field(
         title="Start date for images",
-        default=get_date(Time.now() - 30.0 * u.day),
+        default=None,
         examples=[get_date(Time.now() - 30.0 * u.day), "20230601"],
     )
     end_date: int = Field(
         title="End date for images",
-        default=get_date(Time.now()),
+        default=None,
         examples=[get_date(Time.now() - 30.0 * u.day), get_date(Time.now())],
     )
     image_type: WinterImageTypes = Field(
@@ -52,6 +52,12 @@ class ProgramImageQuery(BaseModel):
 
         :return: validated field value
         """
+        if self.start_date is None:
+            self.start_date = get_date(Time.now() - 30.0 * u.day)
+
+        if self.end_date is None:
+            self.end_date = get_date(Time.now())
+
         if self.start_date > self.end_date:
             raise WinterValidationError("Start date is after end date")
 


### PR DESCRIPTION
This PR changes the default date range to be set dynamically at time of object creation. Makes no difference to API users in almost all cases, but IS important for the API server which can run for weeks and therefore have very outdated default ranges.